### PR TITLE
Removed extraneous colon on SET PYTHON command

### DIFF
--- a/EdgeBugId.cmd
+++ b/EdgeBugId.cmd
@@ -61,7 +61,7 @@ IF NOT EXIST %BugId% (
 )
 
 IF NOT DEFINED PYTHON (
-  SET PYTHON="%SystemDrive%:\Python27\python.exe"
+  SET PYTHON="%SystemDrive%\Python27\python.exe"
 ) ELSE (
   SET PYTHON="%PYTHON:"=%"
 )


### PR DESCRIPTION
There was an extraneous : that caused PYTHON to not be set correctly in Win 10.