### PR TITLE
Removed double %% in when setting KILL

### DIFF
--- a/EdgeWinDbg.cmd
+++ b/EdgeWinDbg.cmd
@@ -40,7 +40,7 @@ IF NOT EXIST %EdgeDbg% (
 )
 
 IF NOT DEFINED Kill (
-  SET Kill="%~dp0modules\Kill\bin\Kill_%%OSISA%%.exe"
+  SET Kill="%~dp0modules\Kill\bin\Kill_%OSISA%.exe"
 ) ELSE (
   SET Kill="%Kill:"=%"
 )


### PR DESCRIPTION
Extraneous %% were surrounding the %OSISA% variable. Removed to get it working in Win 10.